### PR TITLE
Add id register in riscv.ac and remove riscv_isa_helper.H dependence

### DIFF
--- a/riscv.ac
+++ b/riscv.ac
@@ -2,6 +2,7 @@ AC_ARCH(riscv){
 	
 	ac_mem	DM:512M;
 	ac_regbank RB:32;
+  ac_reg  id;
 
 	ac_wordsize 32;
 

--- a/riscv_isa.ac
+++ b/riscv_isa.ac
@@ -9,10 +9,6 @@
 */
 
 AC_ISA(riscv){
-	ac_helper{
-		#include "riscv_isa_helper.H"
-	};
-
 	ac_format Type_R = "%funct7:7 %rs2:5 %rs1:5 %funct3:3 %rd:5 %op:7";
 	ac_format Type_I = "%imm:12 %rs1:5 %funct3:3 %rd:5 %op:7"; 
 	ac_format Type_S = "%imm1:7 %rs2:5 %rs1:5 %funct3:3 %imm2:5 %op:7";


### PR DESCRIPTION
This is necessary to make the model compile with gcc after being
generated by acsim with the acsim riscv.ac -abi command.
